### PR TITLE
The reverse proxy for the terrain API on everdene is deprecated; use …

### DIFF
--- a/datastore.env
+++ b/datastore.env
@@ -21,12 +21,12 @@ IRODS_PASSWORD=
 METADATA_PREFIX=ipc_template
 
 # DE API
-DE_API_HOST=https://everdene.iplantcollaborative.org/
+DE_API_HOST=https://de.cyverse.org/
 DE_API_KEY_PATH=de-api-key.pem
 DE_API_KEY_PASSPHRASE=changeit
 
 # TERRAIN
-TERRAIN_API_HOST=https://everdene.iplantcollaborative.org
+TERRAIN_API_HOST=https://de.cyverse.org
 TERRAIN_API_KEY_PATH=de-api-key.pem
 TERRAIN_API_KEY_PASSPHRASE=changeit
 

--- a/datastore/apps/sra/settings.py
+++ b/datastore/apps/sra/settings.py
@@ -17,6 +17,6 @@ datastore = {
 }
 
 # DE API JWWT
-DE_API_HOST = os.getenv('DE_API_HOST', 'https://everdene.iplantcollaborative.org')
+DE_API_HOST = os.getenv('DE_API_HOST', 'https://de.cyverse.org')
 DE_API_KEY_PATH = os.getenv('DE_API_KEY_PATH', 'de-api-key.pem')
 DE_API_KEY_PASSPHRASE = os.getenv('DE_API_KEY_PASSPHRASE', 'changeit')

--- a/datastore/libs/terrain/settings.py
+++ b/datastore/libs/terrain/settings.py
@@ -1,7 +1,7 @@
 import os
 
 # The Terrian API base path, e.g., scheme://hostname/base
-TERRAIN_API_HOST = os.getenv('TERRAIN_API_HOST', 'https://everdene.iplantcollaborative.org')
+TERRAIN_API_HOST = os.getenv('TERRAIN_API_HOST', 'https://de.cyverse.org')
 
 # The private key used to sign JWT tokens
 TERRAIN_API_KEY_PATH = os.getenv('TERRAIN_API_KEY_PATH', 'de-api-key.pem')

--- a/playbooks/group_vars/edge
+++ b/playbooks/group_vars/edge
@@ -8,6 +8,6 @@ irods_path: /iplant/home/shared
 irods_user: anonymous
 irods_password:
 
-terrain_api_host: https://everdene.iplantcollaborative.org
+terrain_api_host: https://de.cyverse.org
 terrain_api_key_path: /etc/ssl/terrain_api/terrain_api_key.pem
 anon_files_api_host: https://de.cyverse.org/anon-files

--- a/playbooks/group_vars/prod
+++ b/playbooks/group_vars/prod
@@ -8,7 +8,7 @@ irods_path: /iplant/home/shared
 irods_user: anonymous
 irods_password:
 
-terrain_api_host: https://everdene.iplantcollaborative.org
+terrain_api_host: https://de.cyverse.org
 terrain_api_key_path: /etc/ssl/terrain_api/terrain_api_key.pem
 anon_files_api_host: https://de.cyverse.org/anon-files
 

--- a/playbooks/group_vars/qa
+++ b/playbooks/group_vars/qa
@@ -8,7 +8,7 @@ irods_path: /iplant/home/shared
 irods_user: anonymous
 irods_password:
 
-terrain_api_host: https://everdene.iplantcollaborative.org
+terrain_api_host: https://de.cyverse.org
 terrain_api_key_path: /etc/ssl/terrain_api/terrain_api_key.pem
 
 anon_files_api_host: https://de.cyverse.org/anon-files


### PR DESCRIPTION
…the one on de.cyverse.org instead